### PR TITLE
1.35 support

### DIFF
--- a/skins/AtlasMuseum/AtlasMuseum.skin.php
+++ b/skins/AtlasMuseum/AtlasMuseum.skin.php
@@ -30,20 +30,11 @@ class SkinAtlasMuseum extends SkinTemplate {
 			'skins.atlasmuseum.js'
 		) );
 		/* 'skins.atlasmuseum.js' is the name you used in your skin.json file */
-	}
-
-	/**
-	 * Add CSS via ResourceLoader
-	 *
-	 * @param $out OutputPage
-	 */
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
 		$out->addStyle('http://fonts.googleapis.com/css?family=Open+Sans:100,200,400,700|Oswald:100,200,400,700|Libre+Franklin:100,200,400,700', 'screen');
 		$out->addStyle('http://publicartmuseum.net/w/skins/AtlasMuseum/Fonts/font.css', 'screen');
 		/*$out->addScriptFile('http://publicartmuseum.net/w/skins/AtlasMuseum/resources/atlasmuseum.js');*/
 		$out->addModuleStyles( array(
-			'mediawiki.skinning.interface', 'skins.atlasmuseum'
+			'skins.atlasmuseum'
 			/* 'skins.atlasmuseum' is the name you used in your skin.json file */
 		) );
 	}

--- a/skins/AtlasMuseum/AtlasMuseumTemplate.php
+++ b/skins/AtlasMuseum/AtlasMuseumTemplate.php
@@ -34,7 +34,7 @@ class AtlasMuseumTemplate extends BaseTemplate {
 
 				$xmlID = isset( $link['id'] ) ? $link['id'] : 'ca-' . $xmlID;
 				$nav[$section][$key]['attributes'] =
-					' id="' . Sanitizer::escapeId( $xmlID ) . '"';
+					' id="' . Sanitizer::escapeIdForAttribute( $xmlID ) . '"';
 				if ( $link['class'] ) {
 					$nav[$section][$key]['attributes'] .=
 						' class="' . htmlspecialchars( $link['class'] ) . '"';
@@ -200,7 +200,15 @@ class AtlasMuseumTemplate extends BaseTemplate {
 	</ul>
 <?php } ?>
 <?php
-	$footericons = $this->getFooterIcons( "icononly" );
+	$footericons = $this->get('footericons');
+	foreach ( $footericons as $footerIconsKey => &$footerIconsBlock ) {
+		foreach ( $footerIconsBlock as $footerIconKey => $footerIcon ) {
+			if ( !isset( $footerIcon['src'] ) ) {
+				unset( $footerIconsBlock[$footerIconKey] );
+			}
+		}
+	}
+
 	if ( count( $footericons ) > 0 ) {
 ?>
 	<ul id="footer-icons" class="noprint">
@@ -250,7 +258,7 @@ class AtlasMuseumTemplate extends BaseTemplate {
 				case 'SEARCH':
 					break;
 				case 'TOOLBOX':
-					$this->renderPortal( 'tb', $this->getToolbox(), 'toolbox', 'SkinTemplateToolboxEnd' );
+					$this->renderPortal( 'tb', $this->data['sidebar']['TOOLBOX'], 'toolbox', 'SkinTemplateToolboxEnd' );
 					break;
 				case 'LANGUAGES':
 					if ( $this->data['language_urls'] !== false ) {
@@ -275,10 +283,10 @@ class AtlasMuseumTemplate extends BaseTemplate {
 			$msg = $name;
 		}
 		$msgObj = wfMessage( $msg );
-		$labelId = Sanitizer::escapeId( "p-$name-label" );
+		$labelId = Sanitizer::escapeIdForAttribute( "p-$name-label" );
 		?>
 		<div class="portal collapsed" role="navigation" id='<?php
-		echo Sanitizer::escapeId( "p-$name" )
+		echo Sanitizer::escapeIdForAttribute( "p-$name" )
 		?>'<?php
 		echo Linker::tooltip( 'p-' . $name )
 		?> aria-labelledby='<?php echo $labelId ?>'>
@@ -305,7 +313,7 @@ class AtlasMuseumTemplate extends BaseTemplate {
 					echo $content; /* Allow raw HTML block to be defined by extensions */
 				}
 
-				$this->renderAfterPortlet( $name );
+				$this->getSkin()->getAfterPortlet( $name );
 				?>
 			</div>
 		</div>
@@ -496,7 +504,7 @@ class AtlasMuseumTemplate extends BaseTemplate {
 						</h3>
 
 						<form action="<?php $this->text( 'wgScript' ) ?>" id="searchform">
-							<div<?php echo $this->config->get( 'VectorUseSimpleSearch' ) ? ' id="simpleSearch"' : '' ?>>
+							<div id="simpleSearch">
 							<?php
 							echo $this->makeSearchInput( array( 'id' => 'searchInput' ) );
 							echo Html::hidden( 'title', $this->get( 'searchtitle' ) );

--- a/skins/AtlasMuseum/skin.json
+++ b/skins/AtlasMuseum/skin.json
@@ -5,6 +5,7 @@
 	"namemsg": "skinname-atlasmuseum",
 	"license-name": "GPL-2.0+",
 	"type": "skin",
+	"manifest_version": 2,
 	"ValidSkinNames": {
 		"atlasmuseum": "AtlasMuseum"
 	},
@@ -18,7 +19,9 @@
 	"ResourceModules": {
 		"skins.atlasmuseum": {
 			"class": "ResourceLoaderSkinModule",
-			"position": "top",
+			"features": {
+				"interface": true
+			},
 			"styles": {
 				"resources/screen.css": { "media": "screen" }
 			}


### PR DESCRIPTION
Adds 1.35 support. 
Motivation: Provided the skin is still maintained, I would like to showcase on the new skins tool https://skins.wmflabs.org

Replace deprecated functions:
* setupSkinUserCss
* Sanitizer::escapeId
* BaseTemplate::getToolbox

Replace deprecated module mediawiki.skinning.interface with ResourceLoaderSkin
feature